### PR TITLE
Update gen-xauth

### DIFF
--- a/scripts/gen-xauth
+++ b/scripts/gen-xauth
@@ -10,7 +10,7 @@ mkdir -p $(dirname $XAUTH_FILE)
 # attempt to bring host DISPLAY/xauth to container
 
 rm -f $XAUTH_FILE && touch $XAUTH_FILE
-DOCKER_XAUTH=$(xauth list $DISPLAY | awk '{print $3}')
+DOCKER_XAUTH=$(xauth list $DISPLAY | grep $(uname -n) | awk '{print $3}')
 DOCKER_DISPLAY=$DISPLAY
 
 # assume that <hostname>:# displays are TCP displays, use docker host IP as display in container

--- a/scripts/gen-xauth
+++ b/scripts/gen-xauth
@@ -15,7 +15,7 @@ DOCKER_DISPLAY=$DISPLAY
 
 # assume that <hostname>:# displays are TCP displays, use docker host IP as display in container
 # this requres sshd_config option "X11UseLocalhost no"
-if [[ $DISPLAY == $(hostname)* ]]; then
+if [[ $DISPLAY == $(uname -n)* ]]; then
 	DOCKER_DISPLAY="172.17.0.1:$(echo $DISPLAY | cut -d : -f 2)"
 fi
 


### PR DESCRIPTION
Filter the xauth list by the host system's hostname to prevent extra xauth list entries from breaking the  xauth add command.

Change `hostname` command to `uname -a` for better compatibility.