### PR TITLE
Update Dockerfile to make Modelsim work properly in 18.1 version

### DIFF
--- a/Intel_Quartus_Prime_18.1/Dockerfile
+++ b/Intel_Quartus_Prime_18.1/Dockerfile
@@ -5,6 +5,7 @@ RUN 	/quartus/setup.sh --mode unattended --accept_eula 1 --installdir /opt/quart
 
 FROM 	fpga-base:centos6
 COPY 	--from=install /opt/quartus /opt/quartus
+RUN   sed -i 's/linux\_rh[[:digit:]]\+/linux/g' /opt/quartus/modelsim_ase/vco
 CMD 	["/opt/quartus/quartus/bin/quartus", "--64bit"]
 ARG     TOOL
 LABEL   com.halfmanhalftaco.fpga.tool=$TOOL

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #TOOLS += Altera_Quartus_Prime_17.0
 #TOOLS += Altera_Quartus_Prime_17.1
 #TOOLS += Intel_Quartus_Prime_18.0
-#TOOLS += Intel_Quartus_Prime_18.1
+TOOLS += Intel_Quartus_Prime_18.1
 #TOOLS += Intel_Quartus_Prime_19.1
 #TOOLS += Intel_Quartus_Prime_10.1
 #TOOLS += Intel_Quartus_Prime_20.1.1


### PR DESCRIPTION
I really appreciate the work done with this repository, thanks! One little addition: 

I modified the section `vco="linux_rh60"` to  `vco="linux"` in `/opt/quartus/modelsim_ase/vco` file, this grant that the Modelsim works properly in this version.